### PR TITLE
Fix: Delete disconnected Xero connections from database

### DIFF
--- a/backend/services/xeroService.js
+++ b/backend/services/xeroService.js
@@ -507,8 +507,8 @@ class XeroService {
   }
   
   /**
-   * Disconnect/revoke Xero connection
-   * @param {string} connectionId - Connection ID to revoke
+   * Disconnect/delete Xero connection
+   * @param {string} connectionId - Connection ID to delete
    * @param {string} userId - User ID for authorization
    */
   async disconnectXero(connectionId, userId) {
@@ -535,11 +535,12 @@ class XeroService {
         console.warn('Failed to revoke tokens with Xero:', revokeError.message);
       }
       
-      // Update connection status
-      connection.status = 'revoked';
-      await connection.save();
+      // Delete the connection from the database
+      await XeroConnection.deleteOne({ _id: connectionId });
       
-      return connection;
+      console.log(`✅ Successfully deleted Xero connection ${connectionId}`);
+      
+      return { success: true, message: 'Connection deleted successfully' };
     } catch (error) {
       console.error('Disconnect error:', error);
       throw new Error('Failed to disconnect Xero');


### PR DESCRIPTION
## Problem
When disconnecting a Xero connection, it was still appearing in the Connections page under "Inactive Connections". This confused users because they expected the connection to disappear completely after disconnecting.

## Root Cause
The `disconnectXero` function in `backend/services/xeroService.js` was only changing the connection status to `'revoked'` instead of actually deleting the connection from the database.

## Solution
Modified the `disconnectXero` function to completely delete the connection from the database using `XeroConnection.deleteOne()`. 

## Changes Made
- **File:** `backend/services/xeroService.js`
- **Function:** `disconnectXero()`
- **Change:** Replaced `connection.status = 'revoked'; await connection.save();` with `await XeroConnection.deleteOne({ _id: connectionId });`

## Result
- When a user clicks "Disconnect", the connection is now permanently removed from the database
- The connection no longer appears anywhere in the Connections page (neither in Active nor Inactive sections)
- Disconnecting a connection now works as users expect - it's completely gone

## Testing
To test this change:
1. Go to the Connections page
2. Connect to a Xero organization
3. Click the "Disconnect" button
4. Refresh the page
5. Verify the connection no longer appears anywhere on the page

## Notes
- The existing OAuth token revocation with Xero still happens (optional, since tokens expire anyway)
- This is a breaking change only if there was a feature that relied on keeping "revoked" connections - I didn't find any such feature in the codebase
- Historical data from the connection (invoices, contacts) will remain in any separate collections if they exist