### PR TITLE
Fix: Add authentication token to connection stats request

### DIFF
--- a/frontend/src/components/xero/XeroConnectionCard.tsx
+++ b/frontend/src/components/xero/XeroConnectionCard.tsx
@@ -47,9 +47,32 @@ const XeroConnectionCard: React.FC<XeroConnectionCardProps> = ({
   const fetchConnectionStats = async () => {
     try {
       console.log('📊 Fetching connection stats for:', connection._id);
+      
+      // Get the auth token from localStorage
+      const token = localStorage.getItem('token');
+      
+      if (!token) {
+        console.error('❌ No auth token found');
+        setStats({
+          customers: 0,
+          vendors: 0,
+          totalContacts: 0,
+          loading: false,
+          error: 'Authentication required. Please log in again.'
+        });
+        return;
+      }
+      
       const response = await fetch(
-        `https://ledgerlink.onrender.com/api/xero/connection-stats/${connection._id}`
+        `https://ledgerlink.onrender.com/api/xero/connection-stats/${connection._id}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        }
       );
+      
       const data = await response.json();
       
       console.log('📊 Stats response:', data);
@@ -86,8 +109,25 @@ const XeroConnectionCard: React.FC<XeroConnectionCardProps> = ({
   const handleReconnect = async () => {
     console.log('🔄 Reconnecting to Xero...');
     try {
+      // Get the auth token from localStorage
+      const token = localStorage.getItem('token');
+      
+      if (!token) {
+        console.error('❌ No auth token found');
+        return;
+      }
+      
       // Get auth URL from backend
-      const response = await fetch('https://ledgerlink.onrender.com/api/xero/auth');
+      const response = await fetch(
+        'https://ledgerlink.onrender.com/api/xero/auth?companyId=default',
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+      
       const data = await response.json();
       
       if (data.success && data.data.authUrl) {


### PR DESCRIPTION
## Summary
This PR fixes the 401 Unauthorized error when fetching connection statistics.

## The Problem
After deploying the previous fix, the frontend was calling the new `/api/xero/connection-stats` endpoint but getting a 401 error because it wasn't sending the authentication token.

**Error from logs:**
```
GET /api/xero/connection-stats/690b1b9... 401 (Unauthorized)
📊 Stats response: {error: 'Access denied. No valid token provided.'}
```

## The Solution
Updated `XeroConnectionCard.tsx` to include the auth token from localStorage in both:
1. **fetchConnectionStats()** - When loading customer/vendor counts
2. **handleReconnect()** - When getting the Xero OAuth URL

## Changes Made

### Frontend Changes

**`frontend/src/components/xero/XeroConnectionCard.tsx`**

**Before:**
```typescript
const response = await fetch(
  `https://ledgerlink.onrender.com/api/xero/connection-stats/${connection._id}`
);
```

**After:**
```typescript
// Get the auth token from localStorage
const token = localStorage.getItem('token');

if (!token) {
  // Show error to user
  setStats({ error: 'Authentication required. Please log in again.' });
  return;
}

const response = await fetch(
  `https://ledgerlink.onrender.com/api/xero/connection-stats/${connection._id}`,
  {
    headers: {
      'Authorization': `Bearer ${token}`,
      'Content-Type': 'application/json'
    }
  }
);
```

## What This Fixes

### Before ❌
- Frontend calls endpoint without auth token
- Backend rejects with 401 Unauthorized
- Card shows "0 Customers, 0 Vendors"
- No helpful error message

### After ✅
- Frontend includes auth token in request
- Backend accepts request and counts contacts
- Card shows actual counts from Xero
- If token is missing, user sees clear error

## Testing Instructions

After this PR is merged and deployed:

1. **Visit Connections Page**
   - Go to https://ledgerlink.vercel.app/connections
   - You should see your Xero connection

2. **Verify Counts Display**
   - Card should show:
     - **X Customers** (actual count from Xero)
     - **Y Vendors** (actual count from Xero)
   - No 401 errors in browser console

3. **Test Reconnect** (if needed)
   - If Xero auth is expired, click "Reconnect to Xero"
   - Should redirect to Xero login
   - After authorizing, should redirect back with working connection

## Breaking Changes
None. This is a bug fix.

## Dependencies
No new dependencies.

## Deployment Notes
- Frontend will auto-deploy to Vercel (1-2 minutes)
- No backend changes needed
- No database changes needed
- No environment variable changes needed